### PR TITLE
Add missing word in exception message

### DIFF
--- a/packages/reference-finder-extension/lib/ReferenceFinderExtension.php
+++ b/packages/reference-finder-extension/lib/ReferenceFinderExtension.php
@@ -37,7 +37,7 @@ class ReferenceFinderExtension implements Extension
             }
 
             throw new RuntimeException(sprintf(
-                'At least one implementation must be registered with tag "%s"',
+                'At least one implementation finder must be registered with tag "%s"',
                 self::TAG_IMPLEMENTATION_FINDER
             ));
         });


### PR DESCRIPTION
This error message is really confusing since it is
produced when looking for implementations.